### PR TITLE
fix: device card tap target covers full card area

### DIFF
--- a/Traxe/Features/DeviceList/Device/View/DeviceListView.swift
+++ b/Traxe/Features/DeviceList/Device/View/DeviceListView.swift
@@ -198,6 +198,8 @@ struct DeviceListView: View {
                     Spacer()
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding()
@@ -235,7 +237,6 @@ struct DeviceListView: View {
             x: 0,
             y: 4
         )
-        .contentShape(Rectangle())
     }
 
     private func handleDeviceTap(device: SavedDevice, isAccessible: Bool) {


### PR DESCRIPTION
## Summary
- Fixed device card buttons only responding to taps on text content, not the full card area
- Added frame expansion and content shape inside the button label to ensure the entire card is tappable

## Test plan
- [ ] With one device, tap empty space on the card — should navigate to device summary
- [ ] With multiple devices, tap empty space on each card — all should respond
- [ ] Verify tapping text content still works as before

Fixes #32